### PR TITLE
Add simple help text to the MultiRoi screen

### DIFF
--- a/roipoly/roipoly.py
+++ b/roipoly/roipoly.py
@@ -227,12 +227,15 @@ class MultiRoi:
     def make_buttons(self):
         ax_add_btn = plt.axes([0.7, 0.02, 0.1, 0.04])
         ax_finish_btn = plt.axes([0.81, 0.02, 0.1, 0.04])
-        ax_text = plt.axes([0.2, 0.02, 0.4, 0.1])
+        ax_text = plt.axes([0.17, 0.01, 0.52, 0.079],
+                           xticks=[], yticks=[])
         btn_finish = Button(ax_finish_btn, 'Finish')
         btn_finish.on_clicked(self.finish)
         btn_add = Button(ax_add_btn, 'New ROI')
         btn_add.on_clicked(self.add)
-        ax_text.text(0,0, 'Left-click to place, Right-click to finish polygon.')
+        ax_text.text(0.01, 0.1,
+                     'Left-click to place a vertex.\n'
+                     'Right-click to close the polygon.')
         plt.show(block=True)
 
     def add(self, event):

--- a/roipoly/roipoly.py
+++ b/roipoly/roipoly.py
@@ -227,10 +227,12 @@ class MultiRoi:
     def make_buttons(self):
         ax_add_btn = plt.axes([0.7, 0.02, 0.1, 0.04])
         ax_finish_btn = plt.axes([0.81, 0.02, 0.1, 0.04])
+        ax_text = plt.axes([0.2, 0.02, 0.4, 0.1])
         btn_finish = Button(ax_finish_btn, 'Finish')
         btn_finish.on_clicked(self.finish)
         btn_add = Button(ax_add_btn, 'New ROI')
         btn_add.on_clicked(self.add)
+        ax_text.text(0,0, 'Left-click to place, Right-click to finish polygon.')
         plt.show(block=True)
 
     def add(self, event):


### PR DESCRIPTION
For my project, end users who probably have not seen this repository will need to use the MultiRoi tool. However, instructions on how to use it are only currently in the repository, not on the final code itself.

I slightly changed the code to add a simple help text on the GUI while it runs a MultiRoi instance. For comparison, here is the new GUI:
![new-gui](https://user-images.githubusercontent.com/19656507/60474439-d18ed580-9c26-11e9-88d6-c3e2bf8fe026.png)
vs the old one:
![old-gui](https://user-images.githubusercontent.com/19656507/60474440-d6ec2000-9c26-11e9-93ca-ceb63a59b40e.png)


The small box in the bottom left with help text displayed is the only change that this pull request makes.