### PR TITLE
Spyder fixes - addresses issue #29

### DIFF
--- a/roipoly/roipoly.py
+++ b/roipoly/roipoly.py
@@ -1,7 +1,7 @@
 """Draw polygon regions of interest (ROIs) in matplotlib images,
 similar to Matlab's roipoly function.
 """
-
+import os
 import sys
 import logging
 import warnings
@@ -69,15 +69,18 @@ class RoiPoly:
         self.__cid2 = self.fig.canvas.mpl_connect(
             'button_press_event', self.__button_press_callback)
 
+        # determine the type of environment
+        using_spyder = any(['SPYDER' in x for x in os.environ])
+        self.interactive = sys.flags.interactive or using_spyder
+
         if show_fig:
             self.show_figure()
 
-    @staticmethod
-    def show_figure():
-        if sys.flags.interactive:
+    def show_figure(self):
+        while (not self.completed) and self.interactive:
             plt.show(block=False)
-        else:
-            plt.show(block=True)
+            plt.pause(0.1)
+        plt.show(block=True)
 
     def get_mask(self, current_image):
         ny, nx = np.shape(current_image)
@@ -175,7 +178,7 @@ class RoiPoly:
                 self.line = None
                 self.completed = True
 
-                if not sys.flags.interactive and self.close_figure:
+                if self.close_figure:
                     #  Figure has to be closed so that code can continue
                     plt.close(self.fig)
 

--- a/roipoly/roipoly.py
+++ b/roipoly/roipoly.py
@@ -11,6 +11,8 @@ import matplotlib.pyplot as plt
 from matplotlib.path import Path as MplPath
 from matplotlib.widgets import Button
 
+# See if any SPYDER-related variables exist. Source of variables:
+# https://github.com/spyder-ide/spyder/blob/aa9fdaf7379577bdc7c2aa1e2bdc3feb82be953b/spyder/app/restart.py#L189
 USING_SPYDER = any(x in os.environ for x in ['SPYDER_ARGS',
                                              'SPYDER_PID',
                                              'SPYDER_IS_BOOSTRAP',

--- a/roipoly/roipoly.py
+++ b/roipoly/roipoly.py
@@ -11,7 +11,10 @@ import matplotlib.pyplot as plt
 from matplotlib.path import Path as MplPath
 from matplotlib.widgets import Button
 
-USING_SPYDER = any(['SPYDER' in x for x in os.environ])
+USING_SPYDER = any(x in os.environ for x in ['SPYDER_ARGS',
+                                             'SPYDER_PID',
+                                             'SPYDER_IS_BOOSTRAP',
+                                             'SPYDER_RESET'])
 
 logger = logging.getLogger(__name__)
 

--- a/roipoly/roipoly.py
+++ b/roipoly/roipoly.py
@@ -11,6 +11,8 @@ import matplotlib.pyplot as plt
 from matplotlib.path import Path as MplPath
 from matplotlib.widgets import Button
 
+USING_SPYDER = any(['SPYDER' in x for x in os.environ])
+
 logger = logging.getLogger(__name__)
 
 warnings.simplefilter('always', DeprecationWarning)
@@ -69,9 +71,8 @@ class RoiPoly:
         self.__cid2 = self.fig.canvas.mpl_connect(
             'button_press_event', self.__button_press_callback)
 
-        # determine the type of environment
-        using_spyder = any(['SPYDER' in x for x in os.environ])
-        self.interactive = sys.flags.interactive or using_spyder
+        # Determine the type of environment
+        self.interactive = sys.flags.interactive or USING_SPYDER
 
         if show_fig:
             self.show_figure()


### PR DESCRIPTION
This fix should allow spyder users to use the roipoly.py library.

I've tested the fix with both examples in sypder and also using python in interactive mode (i.e. python -i) - everything seems to work as intended (using spyder 4.0.1 and python 3.7.6)

