### PR TITLE
Fix get_mask and display_roi

### DIFF
--- a/roipoly/roipoly.py
+++ b/roipoly/roipoly.py
@@ -80,7 +80,7 @@ class RoiPoly:
             plt.show(block=True)
 
     def get_mask(self, current_image):
-        ny, nx = np.shape(current_image)
+        ny, nx = np.shape(current_image)[0:2]
         poly_verts = ([(self.x[0], self.y[0])]
                       + list(zip(reversed(self.x), reversed(self.y))))
         # Create vertex coordinates for each grid cell...
@@ -99,6 +99,7 @@ class RoiPoly:
         ax = plt.gca()
         ax.add_line(line)
         plt.draw()
+        self.show_figure()
 
     def get_mean_and_std(self, current_image):
         mask = self.get_mask(current_image)

--- a/roipoly/roipoly.py
+++ b/roipoly/roipoly.py
@@ -91,6 +91,7 @@ class RoiPoly:
 
         roi_path = MplPath(poly_verts)
         grid = roi_path.contains_points(points).reshape((ny, nx))
+        grid=grid if current_image.ndim!=3 else np.dstack(tuple([grid for i in range(current_image.shape[2])]))
         return grid
 
     def display_roi(self, **linekwargs):


### PR DESCRIPTION
1. get_mask: Fixing 'valueerror: too many values to unpack (expected 2)' in case of rgb (or >2 dimension) images. 
2. display_roi: Quick fix . **Discretion advised** during merge... 'display_roi' was not displaying image earlier